### PR TITLE
feat: add Snooze Quick Settings tile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.worktrees/
+.superpowers/

--- a/docs/superpowers/specs/2026-04-14-snooze-dnd-design.md
+++ b/docs/superpowers/specs/2026-04-14-snooze-dnd-design.md
@@ -1,0 +1,81 @@
+# Snooze DnD — Design Spec
+
+**Date:** 2026-04-14
+**Status:** Approved
+
+---
+
+## Overview
+
+Add a Quick Settings tile that lets the user temporarily disable Do Not Disturb (snooze) for a chosen duration, overriding the active schedule. When the snooze expires, the normal schedule resumes automatically.
+
+---
+
+## User-Facing Behaviour
+
+- A `QuickMenuToggle` tile labelled "Snooze DnD" appears in the GNOME Quick Settings panel.
+- Clicking the right arrow opens a submenu with four duration options: **30 minutes**, **1 hour**, **2 hours**, **4 hours**.
+- Selecting a duration activates the snooze: the tile turns highlighted (checked), DnD is immediately disabled, and a "Cancel snooze" item appears at the bottom of the submenu (below a separator).
+- Clicking the main toggle button while the snooze is active cancels it immediately.
+- Clicking the main toggle button while inactive is a no-op (snaps back to unchecked); the user must pick a duration from the menu.
+- When the snooze expires the tile returns to unchecked and the normal schedule resumes (within ~1 minute).
+- Snooze state is **in-memory only** — restarting GNOME Shell or rebooting clears it.
+
+---
+
+## Architecture
+
+### Snooze state
+
+A single instance variable `_snooze_until` (JS millisecond timestamp, or `null`) stored on the `DnDExtension` instance. No GSettings key is needed.
+
+### `_enable_if_needed()` — updated logic
+
+```
+if (_snooze_until !== null && Date.now() < _snooze_until):
+    _set_dnd(false)
+    return
+else:
+    if (_snooze_until !== null):
+        _snooze_until = null          // expired — clear it
+        _indicator.sync()             // update tile to unchecked
+    // existing schedule logic unchanged
+```
+
+### `DnDSnoozeIndicator` class
+
+A new class in `extension.js` that encapsulates both the `SystemIndicator` and its `QuickMenuToggle`:
+
+| Responsibility | Detail |
+|---|---|
+| Create toggle | `QuickMenuToggle` with label "Snooze DnD" and a bell-slash icon |
+| Build submenu | Four `PopupMenuItem` entries for durations + separator + Cancel item |
+| `_activate(minutes)` | Sets `extension._snooze_until`, calls `_enable_if_needed()`, syncs UI |
+| `_cancel()` | Clears `extension._snooze_until`, calls `_enable_if_needed()`, syncs UI |
+| `sync()` | Updates toggle `checked` state and Cancel item visibility |
+| Toggle click | If checked -> `_cancel()`; if unchecked -> revert (no-op) |
+
+### `enable()` / `disable()` changes
+
+- `enable()`: instantiates `DnDSnoozeIndicator`, stores it as `this._indicator`, adds it to `Main.panel.statusArea.quickSettings`.
+- `disable()`: destroys the indicator, sets `this._indicator = null` and `this._snooze_until = null`.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `extension.js` | Add `DnDSnoozeIndicator` class; update `_enable_if_needed()`; wire up in `enable()`/`disable()` |
+| `prefs.js` | No changes |
+| `schemas/` | No changes |
+| `metadata.json` | No changes |
+
+---
+
+## Out of Scope
+
+- Countdown display on the tile (no "47 min remaining" subtitle).
+- Persisting snooze across restarts.
+- Configurable default snooze duration.
+- Notifications when snooze expires.

--- a/extension.js
+++ b/extension.js
@@ -41,7 +41,7 @@ class DnDSnoozeIndicator extends SystemIndicator {
         this._ext = extension;
 
         this._toggle = new QuickMenuToggle({
-            title: 'Snooze DnD',
+            title: 'Snooze',
             iconName: 'notifications-disabled-symbolic',
         });
         this._toggle.connect('clicked', this._onToggleClicked.bind(this));

--- a/extension.js
+++ b/extension.js
@@ -19,6 +19,10 @@
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import {QuickMenuToggle, SystemIndicator} from 'resource:///org/gnome/shell/ui/quickSettings.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 export default class DnDExtension extends Extension {

--- a/extension.js
+++ b/extension.js
@@ -120,17 +120,27 @@ export default class DnDExtension extends Extension {
     }
 
     _enable_if_needed() {
+        // Snooze override: force DnD off while snooze is active
+        if (this._snooze_until !== null && Date.now() < this._snooze_until) {
+            this._set_dnd(false);
+            return;
+        }
+
+        // Snooze just expired — clear it and update the tile
+        if (this._snooze_until !== null) {
+            this._snooze_until = null;
+            this._indicator?.sync();
+        }
 
         let time = this._get_time();
         let enable_time = this.__settings.get_int('enable-dnd-time-offset');
         let disable_time = this.__settings.get_int('disable-dnd-time-offset');
 
-        let dnd = ((enable_time < time && time < disable_time) || 
+        let dnd = ((enable_time < time && time < disable_time) ||
                   (enable_time > disable_time &&
-                  (time <= disable_time || time >= enable_time)))
-        
+                  (time <= disable_time || time >= enable_time)));
+
         this._set_dnd(dnd);
-        
     }
     
     _set_dnd(value) {

--- a/extension.js
+++ b/extension.js
@@ -95,23 +95,26 @@ class DnDSnoozeIndicator extends SystemIndicator {
 export default class DnDExtension extends Extension {
 
     enable() {
+        this._snooze_until = null;
 
         this.__notification_settings = new Gio.Settings({
-            schema_id: "org.gnome.desktop.notifications",
-        })
+            schema_id: 'org.gnome.desktop.notifications',
+        });
 
         this.__old_dnd = !this.__notification_settings.get_boolean('show-banners');
         this.__current_value = this.__old_dnd;
 
         this.__settings = this.getSettings('org.gnome.shell.extensions.dndsched');
 
+        this._indicator = new DnDSnoozeIndicator(this);
+        Main.panel.statusArea.quickSettings.addExternalIndicator(this._indicator);
+
         this._enable_if_needed();
-        
-        this. __check_tid = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 60, this._regular_check.bind(this));
+
+        this.__check_tid = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 60, this._regular_check.bind(this));
 
         this.__settings_enable_cid = this.__settings.connect('changed::enable-dnd-time-offset', this._enable_if_needed.bind(this));
         this.__settings_disable_cid = this.__settings.connect('changed::disable-dnd-time-offset', this._enable_if_needed.bind(this));
-
     }
 
     _regular_check() {
@@ -163,7 +166,6 @@ export default class DnDExtension extends Extension {
     }
 
     disable() {
-
         if (this.__settings_enable_cid) {
             this.__settings.disconnect(this.__settings_enable_cid);
             this.__settings_enable_cid = null;
@@ -175,14 +177,19 @@ export default class DnDExtension extends Extension {
         }
 
         this._cleanup();
-        
+
+        if (this._indicator) {
+            this._indicator.quickSettingsItems.forEach(item => item.destroy());
+            this._indicator.destroy();
+            this._indicator = null;
+        }
+
+        this._snooze_until = null;
+
         this._set_dnd(this.__old_dnd);
 
-        this.__dnd = null;
         this.__current_value = null;
-
         this.__settings = null;
         this.__notification_settings = null;
-        
     }
 }

--- a/extension.js
+++ b/extension.js
@@ -63,6 +63,10 @@ class DnDSnoozeIndicator extends SystemIndicator {
         this._cancelItem.connect('activate', () => this._cancel());
         this._toggle.menu.addMenuItem(this._cancelItem);
 
+        const settingsItem = new PopupMenu.PopupMenuItem('Schedule settings\u2026');
+        settingsItem.connect('activate', () => this._ext.openPreferences());
+        this._toggle.menu.addMenuItem(settingsItem);
+
         this.sync();
     }
 

--- a/extension.js
+++ b/extension.js
@@ -129,9 +129,9 @@ export default class DnDExtension extends Extension {
     }
 
     _enable_if_needed() {
-        // Snooze override: force DnD off while snooze is active
+        // Snooze override: force DnD on while snooze is active
         if (this._snooze_until !== null && Date.now() < this._snooze_until) {
-            this._set_dnd(false);
+            this._set_dnd(true);
             return;
         }
 

--- a/extension.js
+++ b/extension.js
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 
@@ -32,6 +33,7 @@ const SNOOZE_DURATIONS = [
     {label: '4 hours',    minutes: 240},
 ];
 
+const DnDSnoozeIndicator = GObject.registerClass(
 class DnDSnoozeIndicator extends SystemIndicator {
 
     constructor(extension) {
@@ -90,7 +92,7 @@ class DnDSnoozeIndicator extends SystemIndicator {
         this._toggle.checked = active;
         this._cancelItem.visible = active;
     }
-}
+});
 
 export default class DnDExtension extends Extension {
 

--- a/extension.js
+++ b/extension.js
@@ -25,6 +25,73 @@ import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
+const SNOOZE_DURATIONS = [
+    {label: '30 minutes', minutes: 30},
+    {label: '1 hour',     minutes: 60},
+    {label: '2 hours',    minutes: 120},
+    {label: '4 hours',    minutes: 240},
+];
+
+class DnDSnoozeIndicator extends SystemIndicator {
+
+    constructor(extension) {
+        super();
+        this._ext = extension;
+
+        this._toggle = new QuickMenuToggle({
+            title: 'Snooze DnD',
+            iconName: 'notifications-disabled-symbolic',
+        });
+        this._toggle.connect('clicked', this._onToggleClicked.bind(this));
+        this.quickSettingsItems.push(this._toggle);
+
+        this._buildMenu();
+    }
+
+    _buildMenu() {
+        for (const {label, minutes} of SNOOZE_DURATIONS) {
+            const item = new PopupMenu.PopupMenuItem(label);
+            item.connect('activate', () => this._activate(minutes));
+            this._toggle.menu.addMenuItem(item);
+        }
+
+        this._toggle.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        this._cancelItem = new PopupMenu.PopupMenuItem('Cancel snooze');
+        this._cancelItem.connect('activate', () => this._cancel());
+        this._toggle.menu.addMenuItem(this._cancelItem);
+
+        this.sync();
+    }
+
+    _activate(minutes) {
+        this._ext._snooze_until = Date.now() + minutes * 60 * 1000;
+        this._ext._enable_if_needed();
+        this.sync();
+    }
+
+    _cancel() {
+        this._ext._snooze_until = null;
+        this._ext._enable_if_needed();
+        this.sync();
+    }
+
+    _onToggleClicked() {
+        const snoozed = this._ext._snooze_until !== null &&
+                        Date.now() < this._ext._snooze_until;
+        if (snoozed)
+            this._cancel();
+        // else: no active snooze — ignore click, toggle stays unchecked
+    }
+
+    sync() {
+        const active = this._ext._snooze_until !== null &&
+                       Date.now() < this._ext._snooze_until;
+        this._toggle.checked = active;
+        this._cancelItem.visible = active;
+    }
+}
+
 export default class DnDExtension extends Extension {
 
     enable() {


### PR DESCRIPTION
## Summary

- Adds a **Snooze** `QuickMenuToggle` tile to the GNOME Quick Settings panel
- Selecting a duration (30 min / 1 h / 2 h / 4 h) forces Do Not Disturb ON for that period, overriding the schedule
- Tile highlights while snooze is active; submenu includes **Cancel snooze** and **Schedule settings…** (opens prefs)
- Snooze state is in-memory only — cleared on GNOME Shell restart or extension disable
- Tested on GNOME 46 (Ubuntu 24.04)

## Changes

- `extension.js`: add `GObject`, `Main`, `QuickMenuToggle`/`SystemIndicator`, `PopupMenu` imports; add `DnDSnoozeIndicator` class; update `_enable_if_needed()`, `enable()`, `disable()`
- No schema or prefs changes

## Test Plan

- [ ] Snooze tile appears in Quick Settings after enabling extension
- [ ] Selecting a duration turns DnD ON for that period
- [ ] Cancel snooze via submenu or tile button restores schedule state
- [ ] Schedule settings… opens the preferences window
- [ ] Snooze clears on extension disable / shell restart